### PR TITLE
Pods

### DIFF
--- a/Covid.xcodeproj/project.pbxproj
+++ b/Covid.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		0FF4F220241AF21200643297 /* APIResponses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FF4F21F241AF21200643297 /* APIResponses.swift */; };
 		0FF4F224241AF61600643297 /* APIRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FF4F223241AF61600643297 /* APIRequests.swift */; };
 		1EACF742EFBC189662F2C060 /* Pods_Covid.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C8E1E3496C8614E26AC81B2B /* Pods_Covid.framework */; };
+		21DE1B4D2435DA7500746CE8 /* iengine.lic in Resources */ = {isa = PBXBuildFile; fileRef = 21DE1B4C2435DA7500746CE8 /* iengine.lic */; };
 		6BD00FEB241FEF02001BCE50 /* SearchMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD00FEA241FEF02001BCE50 /* SearchMapViewController.swift */; };
 		C0091574241EBCD10012F557 /* CountryCodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0091573241EBCD10012F557 /* CountryCodeViewController.swift */; };
 		C0091576241EC10B0012F557 /* CountryCodes.json in Resources */ = {isa = PBXBuildFile; fileRef = C0091575241EC10B0012F557 /* CountryCodes.json */; };
@@ -129,6 +130,7 @@
 		0FF4F21D241AEFBB00643297 /* CovidService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CovidService.swift; sourceTree = "<group>"; };
 		0FF4F21F241AF21200643297 /* APIResponses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIResponses.swift; sourceTree = "<group>"; };
 		0FF4F223241AF61600643297 /* APIRequests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIRequests.swift; sourceTree = "<group>"; };
+		21DE1B4C2435DA7500746CE8 /* iengine.lic */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = iengine.lic; sourceTree = "<group>"; };
 		6BD00FEA241FEF02001BCE50 /* SearchMapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchMapViewController.swift; sourceTree = "<group>"; };
 		C0091573241EBCD10012F557 /* CountryCodeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryCodeViewController.swift; sourceTree = "<group>"; };
 		C0091575241EC10B0012F557 /* CountryCodes.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = CountryCodes.json; sourceTree = "<group>"; };
@@ -201,6 +203,7 @@
 		0F1181302416C70500213533 = {
 			isa = PBXGroup;
 			children = (
+				21DE1B4C2435DA7500746CE8 /* iengine.lic */,
 				0F74576F241D9342000546FA /* GoogleService-Info.plist */,
 				0F11813B2416C70500213533 /* Covid */,
 				0F11813A2416C70500213533 /* Products */,
@@ -499,6 +502,7 @@
 				C03E09EA242013CB00B3A204 /* Poppins-Italic.otf in Resources */,
 				C03E0A02242013CB00B3A204 /* Inter-UI-Bold.otf in Resources */,
 				0FD28B1B242827330015F7E7 /* okresy.json in Resources */,
+				21DE1B4D2435DA7500746CE8 /* iengine.lic in Resources */,
 				C03E09FE242013CB00B3A204 /* Inter-ExtraLightItalic.otf in Resources */,
 				C03E09F0242013CB00B3A204 /* Poppins-BlackItalic.otf in Resources */,
 				C03E0A11242013CB00B3A204 /* Inter-ExtraLight.otf in Resources */,
@@ -795,6 +799,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 16;
 				DEVELOPMENT_TEAM = "";
+				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = Covid/Resources/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -816,6 +821,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 16;
 				DEVELOPMENT_TEAM = "";
+				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = Covid/Resources/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,8 @@
 # Uncomment the next line to define a global platform for your project
- platform :ios, '10.0'
+platform :ios, '10.1'
+
+source 'https://github.com/CocoaPods/Specs.git'
+source 'https://github.com/innovatrics/innovatrics-podspecs'
 
 target 'Covid' do
   use_frameworks!
@@ -10,6 +13,7 @@ target 'Covid' do
   pod 'Firebase/Analytics'
   pod 'Firebase/Crashlytics'
   pod 'Firebase/RemoteConfig'
-  # Pods for Covid
+
+  pod 'dot'
 
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,32 +1,34 @@
 PODS:
-  - Firebase/Analytics (6.20.0):
+  - dot (2.14.2):
+    - iface (~> 3.8.1)
+  - Firebase/Analytics (6.21.0):
     - Firebase/Core
-  - Firebase/Core (6.20.0):
+  - Firebase/Core (6.21.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (= 6.3.1)
-  - Firebase/CoreOnly (6.20.0):
-    - FirebaseCore (= 6.6.4)
-  - Firebase/Crashlytics (6.20.0):
+    - FirebaseAnalytics (= 6.4.0)
+  - Firebase/CoreOnly (6.21.0):
+    - FirebaseCore (= 6.6.5)
+  - Firebase/Crashlytics (6.21.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 4.0.0-beta.5)
-  - Firebase/RemoteConfig (6.20.0):
+    - FirebaseCrashlytics (~> 4.0.0-beta.6)
+  - Firebase/RemoteConfig (6.21.0):
     - Firebase/CoreOnly
     - FirebaseRemoteConfig (~> 4.4.9)
   - FirebaseABTesting (3.2.0):
     - FirebaseAnalyticsInterop (~> 1.3)
     - FirebaseCore (~> 6.1)
     - Protobuf (>= 3.9.2, ~> 3.9)
-  - FirebaseAnalytics (6.3.1):
+  - FirebaseAnalytics (6.4.0):
     - FirebaseCore (~> 6.6)
     - FirebaseInstallations (~> 1.1)
-    - GoogleAppMeasurement (= 6.3.1)
+    - GoogleAppMeasurement (= 6.4.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
     - GoogleUtilities/MethodSwizzler (~> 6.0)
     - GoogleUtilities/Network (~> 6.0)
     - "GoogleUtilities/NSData+zlib (~> 6.0)"
     - nanopb (= 0.3.9011)
   - FirebaseAnalyticsInterop (1.5.0)
-  - FirebaseCore (6.6.4):
+  - FirebaseCore (6.6.5):
     - FirebaseCoreDiagnostics (~> 1.2)
     - FirebaseCoreDiagnosticsInterop (~> 1.2)
     - GoogleUtilities/Environment (~> 6.5)
@@ -38,12 +40,15 @@ PODS:
     - GoogleUtilities/Logger (~> 6.5)
     - nanopb (~> 0.3.901)
   - FirebaseCoreDiagnosticsInterop (1.2.0)
-  - FirebaseCrashlytics (4.0.0-beta.5):
+  - FirebaseCrashlytics (4.0.0-beta.6):
     - FirebaseAnalyticsInterop (~> 1.2)
     - FirebaseCore (~> 6.6)
     - FirebaseInstallations (~> 1.1)
+    - GoogleDataTransport (~> 5.1)
+    - GoogleDataTransportCCTSupport (>= 2.0.1, ~> 2.0)
+    - nanopb (~> 0.3.901)
     - PromisesObjC (~> 1.2)
-  - FirebaseInstallations (1.1.0):
+  - FirebaseInstallations (1.1.1):
     - FirebaseCore (~> 6.6)
     - GoogleUtilities/UserDefaults (~> 6.5)
     - PromisesObjC (~> 1.2)
@@ -60,15 +65,15 @@ PODS:
     - GoogleUtilities/Environment (~> 6.2)
     - "GoogleUtilities/NSData+zlib (~> 6.2)"
     - Protobuf (>= 3.9.2, ~> 3.9)
-  - GoogleAppMeasurement (6.3.1):
+  - GoogleAppMeasurement (6.4.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
     - GoogleUtilities/MethodSwizzler (~> 6.0)
     - GoogleUtilities/Network (~> 6.0)
     - "GoogleUtilities/NSData+zlib (~> 6.0)"
     - nanopb (= 0.3.9011)
-  - GoogleDataTransport (5.0.0)
-  - GoogleDataTransportCCTSupport (2.0.0):
-    - GoogleDataTransport (~> 5.0)
+  - GoogleDataTransport (5.1.0)
+  - GoogleDataTransportCCTSupport (2.0.1):
+    - GoogleDataTransport (~> 5.1)
     - nanopb (~> 0.3.901)
   - GoogleUtilities/AppDelegateSwizzler (6.5.2):
     - GoogleUtilities/Environment
@@ -88,6 +93,7 @@ PODS:
     - GoogleUtilities/Logger
   - GoogleUtilities/UserDefaults (6.5.2):
     - GoogleUtilities/Logger
+  - iface (3.8.1)
   - nanopb (0.3.9011):
     - nanopb/decode (= 0.3.9011)
     - nanopb/encode (= 0.3.9011)
@@ -99,6 +105,7 @@ PODS:
   - SwiftyUserDefaults (5.0.0)
 
 DEPENDENCIES:
+  - dot
   - Firebase/Analytics
   - Firebase/Crashlytics
   - Firebase/RemoteConfig
@@ -106,7 +113,7 @@ DEPENDENCIES:
   - SwiftyUserDefaults (~> 5.0)
 
 SPEC REPOS:
-  trunk:
+  https://github.com/CocoaPods/Specs.git:
     - Firebase
     - FirebaseABTesting
     - FirebaseAnalytics
@@ -127,29 +134,34 @@ SPEC REPOS:
     - Protobuf
     - ReachabilitySwift
     - SwiftyUserDefaults
+  https://github.com/innovatrics/innovatrics-podspecs:
+    - dot
+    - iface
 
 SPEC CHECKSUMS:
-  Firebase: fe7f74012742ab403451dd283e6909b8f1fb348a
+  dot: 20df3ef7e26864a7b04c216607cb683a5089d196
+  Firebase: f378c80340dd41c0ad0914af740c021eb282a04b
   FirebaseABTesting: 821a3a3e4a145987e80fee3657c4de1cb9adf693
-  FirebaseAnalytics: 572e467f3d977825266e8ccd52674aa3e6f47eac
+  FirebaseAnalytics: a1a0b3327ceb5cd5b4bacffdb293f6c909aa087d
   FirebaseAnalyticsInterop: 3f86269c38ae41f47afeb43ebf32a001f58fcdae
-  FirebaseCore: ed0a24c758a57c2b88c5efa8e6a8195e868af589
+  FirebaseCore: 9f495d3afacb7b558711e6218ebb14b1c51b5802
   FirebaseCoreDiagnostics: e9b4cd8ba60dee0f2d13347332e4b7898cca5b61
   FirebaseCoreDiagnosticsInterop: 296e2c5f5314500a850ad0b83e9e7c10b011a850
-  FirebaseCrashlytics: 7c95218730d1debf493e987233c7b41dd7ba1329
-  FirebaseInstallations: 575cd32f2aec0feeb0e44f5d0110a09e5e60b47b
+  FirebaseCrashlytics: b9e729da8b80d9c45f234f791a73b5fe647d4c31
+  FirebaseInstallations: acb3216eb9784d3b1d2d2d635ff74fa892cc0c44
   FirebaseInstanceID: 7ee0d6777013bb952f377b41965bf132b6a075be
   FirebaseRemoteConfig: 47abf7a04a9082091955ea555aa79cfdd249b19c
-  GoogleAppMeasurement: c29d405ff76e18551b5d158eaba6753fda8c7542
-  GoogleDataTransport: a857c6a002d201b524dd4bc2ed7e7355ed07e785
-  GoogleDataTransportCCTSupport: 32f75fbe904c82772fcbb6b6bd4525bfb6f2a862
+  GoogleAppMeasurement: 6e68a94d0eaeb1d73ef6b0ed4f7334e29d63ae29
+  GoogleDataTransport: b29a21d813e906014ca16c00897827e40e4a24ab
+  GoogleDataTransportCCTSupport: 6f15a89b0ca35d6fa523e1f752ef818588885988
   GoogleUtilities: ad0f3b691c67909d03a3327cc205222ab8f42e0e
+  iface: 9920049baaf8d0cf204e5254cbcd49901f42a2bc
   nanopb: 18003b5e52dab79db540fe93fe9579f399bd1ccd
   PromisesObjC: c119f3cd559f50b7ae681fa59dc1acd19173b7e6
   Protobuf: 176220c526ad8bd09ab1fb40a978eac3fef665f7
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   SwiftyUserDefaults: 33fcb42bd1feb53a37d873feb62c82967db5f7f6
 
-PODFILE CHECKSUM: 32a03b9772a9a5c3bece78d24845de4265c42e6a
+PODFILE CHECKSUM: 3a595001d1d8ee1e6d9e0b0aea645355ddc1855d
 
 COCOAPODS: 1.9.1


### PR DESCRIPTION
**Changes:**

**Pods for Innovatrics:**
_dot (2.14.2)
dot-nfcreader (1.0.3)
iface (3.8.1)
innovatrics-openssl (1.0.3)_

-> Innovatrics frameworks dont come with bitcode, this required the bitcode to be turned off for the app:
```
ENABLE_BITCODE = NO;
```

**Other Pods:**
_Firebase 6.21.0
FirebaseAnalytics 6.4.0
FirebaseCore 6.6.5
FirebaseCrashlytics 4.0.0-beta.6
FirebaseInstallations 1.1.1
GoogleAppMeasurement 6.4.0
GoogleDataTransport 5.1.0
GoogleDataTransportCCTSupport 2.0.1_