### PR TITLE
Cover uncovered cases in liveness check

### DIFF
--- a/Covid/Quarantine/FaceID/FaceCaptureCoordinator.swift
+++ b/Covid/Quarantine/FaceID/FaceCaptureCoordinator.swift
@@ -73,7 +73,7 @@ extension FaceCaptureCoordinator {
     // MARK: Onboarding
 
     func showOnboarding(in navigationController: UINavigationController) {
-        let storyboard = UIStoryboard(name: "Main", bundle: Bundle.main)
+        let storyboard = UIStoryboard.main
         if let viewController = storyboard.instantiateViewController(withIdentifier: "faceCaptureOnboarding") as? FaceCaptureOnboardingViewController {
             viewController.onStart = { [weak self] in
                 if let controller = self?.startFaceCapture() {
@@ -191,8 +191,7 @@ extension FaceCaptureCoordinator {
 
 extension FaceCaptureCoordinator: LivenessStepDelegate {
 
-    func liveness(_ step: LivenessStepCoordinator, didSucceed score: Float, capturedSegmentImages segmentImages: [SegmentImage]) {
-        print("didSucceed")
+    private func validateSegmentImages(_ segmentImages: [SegmentImage]) {
         let result = faceIdValidator.validateSegmentImagesToReferenceTemplate(segmentImages)
         switch result {
         case .success:
@@ -201,22 +200,25 @@ extension FaceCaptureCoordinator: LivenessStepDelegate {
         default:
             break
         }
+    }
+
+    func liveness(_ step: LivenessStepCoordinator, didSucceed score: Float, capturedSegmentImages segmentImages: [SegmentImage]) {
+        debugPrint(#function)
+        validateSegmentImages(segmentImages)
         step.stopVerifying()
     }
 
     func liveness(_ step: LivenessStepCoordinator, didFailed score: Float, capturedSegmentImages segmentImages: [SegmentImage]) {
-        print("didFailed")
-
-        let result = faceIdValidator.validateSegmentImagesToReferenceTemplate(segmentImages)
-        switch result {
-        case .success:
-            print("verify: success")
-        default:
-            break
-        }
+        debugPrint(#function)
+        validateSegmentImages(segmentImages)
     }
 
     func livenessdidFailedWithEyesNotDetected(_ step: LivenessStepCoordinator) {
+        debugPrint(#function)
+        livenessFailed(step)
+    }
+
+    func livenessFailed(_ step: LivenessStepCoordinator) {
         switch useCase {
         case .registerFace:
             askToVerifyAgain { _ in
@@ -234,7 +236,6 @@ extension FaceCaptureCoordinator: LivenessStepDelegate {
                 step.restartVerifying()
             }
         }
-        print(#function)
     }
 }
 

--- a/Covid/Resources/Info.plist
+++ b/Covid/Resources/Info.plist
@@ -20,6 +20,8 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
 	<key>LSRequiresIPhoneOS</key>

--- a/Covid/Services/FaceID/FaceIDStepVerifier.swift
+++ b/Covid/Services/FaceID/FaceIDStepVerifier.swift
@@ -37,16 +37,6 @@ protocol LivenessStepDelegate: class {
     func liveness(_ step: LivenessStepCoordinator, didFailed score: Float, capturedSegmentImages segmentImages: [SegmentImage])
     func livenessdidFailedWithEyesNotDetected(_ step: LivenessStepCoordinator)
     func livenessFailed(_ step: LivenessStepCoordinator)
-    func livenessInterrupted(_ step: LivenessStepCoordinator)
-    func livenessIncompatibleTemplate(_ step: LivenessStepCoordinator)
-    func livenessTemplateNotMatching(_ step: LivenessStepCoordinator)
-}
-
-extension LivenessStepDelegate {
-    func livenessFailed(_ step: LivenessStepCoordinator) {}
-    func livenessInterrupted(_ step: LivenessStepCoordinator) {}
-    func livenessIncompatibleTemplate(_ step: LivenessStepCoordinator) {}
-    func livenessTemplateNotMatching(_ step: LivenessStepCoordinator) {}
 }
 
 final class LivenessStepCoordinator {
@@ -113,7 +103,8 @@ extension LivenessStepCoordinator: LivenessCheckControllerDelegate {
 
     func livenessCheck(_ controller: LivenessCheckController, checkDoneWith score: Float, capturedSegmentImages segmentImagesList: [SegmentImage]) {
         debugPrint(#function, segmentImagesList.count)
-        restartVerifying()
+        controller.restartTransitionView()
+        controller.startLivenessCheck()
 
         if score > 0.95 {
             delegate?.liveness(self, didSucceed: score, capturedSegmentImages: segmentImagesList)
@@ -129,6 +120,9 @@ extension LivenessStepCoordinator: LivenessCheckControllerDelegate {
             failCount += 1
             if failCount == Self.maxFailCount {
                 failCount = 0
+                controller.restartTransitionView()
+                controller.stopLivenessCheck()
+                delegate?.livenessFailed(self)
             } else {
                 restartVerifying()
             }


### PR DESCRIPTION
# Changes

* Couple of calls to handle the restart of liveness check were lost in previous PR - these cases are now properly covered
* `ITSAppUsesNonExemptEncryption` = `NO`