### PR TITLE
remote config to enable/disable location tracking for connections

### DIFF
--- a/Covid/AppDelegate.swift
+++ b/Covid/AppDelegate.swift
@@ -164,7 +164,8 @@ extension AppDelegate {
                                             "apiHost": NSString(string: "https://covid-gateway.azurewebsites.net"),
                                             "statsUrl": NSString(string: "https://corona-stats-sk.herokuapp.com/combined"),
                                             "faceIDConfidenceThreshold": NSNumber(value: 600),
-                                            "faceIDMatchThreshold": NSNumber(value: 75)]
+                                            "faceIDMatchThreshold": NSNumber(value: 75),
+                                            "iBeaconLocationAccuracy": NSNumber(value: -1)]
 
         let settings = RemoteConfigSettings()
         settings.minimumFetchInterval = 0

--- a/Covid/Services/LocationServices/BeaconManager.swift
+++ b/Covid/Services/LocationServices/BeaconManager.swift
@@ -23,6 +23,7 @@
 
 import CoreLocation
 import CoreBluetooth
+import SwiftyUserDefaults
 
 struct BeaconId {
     let minor: UInt16
@@ -61,10 +62,10 @@ final class BeaconManager: NSObject {
     override private init() {
         super.init()
 
-        locationManager.requestAlwaysAuthorization()
-        locationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters
-        locationManager.allowsBackgroundLocationUpdates = true
         locationManager.delegate = self
+        if (Firebase.remoteConfig?.configValue(forKey: "ibeaconLocationAccuracy").numberValue ?? -1) != -1 {
+            activateLocationTrackingForBeacons()
+        }
 
         peripheralManager = CBPeripheralManager(
             delegate: self,
@@ -74,6 +75,12 @@ final class BeaconManager: NSObject {
 //                CBPeripheralManagerOptionRestoreIdentifierKey: "advertiserIdentifier"
             ]
         )
+    }
+    
+    func activateLocationTrackingForBeacons() {
+        locationManager.requestAlwaysAuthorization()
+        locationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+        locationManager.allowsBackgroundLocationUpdates = true
     }
 
     func startMonitoring() {

--- a/Covid/Services/Networking/APIRequests.swift
+++ b/Covid/Services/Networking/APIRequests.swift
@@ -152,8 +152,8 @@ struct Connection: Codable, Hashable, Equatable {
     let seenProfileId: Int
     let timestamp: Int
     let duration: String
-    let latitude: Double
-    let longitude: Double
+    let latitude: Double?
+    let longitude: Double?
     let accuracy: Double
 
     func hash(into hasher: inout Hasher) {


### PR DESCRIPTION
Use remote config for:
- enabling / disabling location tracking
- set accuracy of location if tracking is enabled