### PR TITLE
Flows

### DIFF
--- a/Covid.xcodeproj/project.pbxproj
+++ b/Covid.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		21B0F85B2438D0AA00552491 /* NotificationCenterObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B0F85A2438D0AA00552491 /* NotificationCenterObserver.swift */; };
 		21B0F8922438D37D00552491 /* FaceIDNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B0F8912438D37D00552491 /* FaceIDNotification.swift */; };
 		21B0F8942439194100552491 /* UIStoryBoard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B0F8932439194100552491 /* UIStoryBoard.swift */; };
+		21C12B33243D21EF0086AF8B /* Segue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C12B32243D21EF0086AF8B /* Segue.swift */; };
 		21DE1B4D2435DA7500746CE8 /* iengine.lic in Resources */ = {isa = PBXBuildFile; fileRef = 21DE1B4C2435DA7500746CE8 /* iengine.lic */; };
 		21DE1B552435F5C700746CE8 /* CovidTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DE1B542435F5C700746CE8 /* CovidTests.swift */; };
 		6BD00FEB241FEF02001BCE50 /* SearchMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD00FEA241FEF02001BCE50 /* SearchMapViewController.swift */; };
@@ -173,6 +174,7 @@
 		21B0F85A2438D0AA00552491 /* NotificationCenterObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationCenterObserver.swift; sourceTree = "<group>"; };
 		21B0F8912438D37D00552491 /* FaceIDNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaceIDNotification.swift; sourceTree = "<group>"; };
 		21B0F8932439194100552491 /* UIStoryBoard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIStoryBoard.swift; sourceTree = "<group>"; };
+		21C12B32243D21EF0086AF8B /* Segue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Segue.swift; sourceTree = "<group>"; };
 		21DE1B4C2435DA7500746CE8 /* iengine.lic */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = iengine.lic; sourceTree = "<group>"; };
 		21DE1B522435F5C700746CE8 /* CovidTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CovidTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		21DE1B542435F5C700746CE8 /* CovidTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CovidTests.swift; sourceTree = "<group>"; };
@@ -291,6 +293,7 @@
 				0FCB4F0624238B7700389493 /* Quarantine */,
 				0F247F04241A617000986740 /* Resources */,
 				213B74D82437E69F005BB14F /* Services */,
+				21C12B32243D21EF0086AF8B /* Segue.swift */,
 			);
 			path = Covid;
 			sourceTree = "<group>";
@@ -782,6 +785,7 @@
 				0F629282241D4F5A00FF5E14 /* LocationTracker.swift in Sources */,
 				C0F9962D241FCB04009C6BF5 /* PreventionTableViewCell.swift in Sources */,
 				2189714D24368B5C009987EA /* FaceIDCapture.swift in Sources */,
+				21C12B33243D21EF0086AF8B /* Segue.swift in Sources */,
 				213B74DD2437E7BE005BB14F /* FaceCaptureCoordinator.swift in Sources */,
 				C0F99635241FE632009C6BF5 /* SymptomsViewController.swift in Sources */,
 				0FD28B172426EBD30015F7E7 /* SpreadViewController.swift in Sources */,

--- a/Covid/AppDelegate.swift
+++ b/Covid/AppDelegate.swift
@@ -54,12 +54,6 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         setupFirebaseConfig()
         Crashlytics.crashlytics().setUserID(Defaults.deviceId)
         UITabBar.appearance().unselectedItemTintColor = UIColor(red: 150 / 255.0, green: 161 / 255.0, blue: 205 / 255.0, alpha: 1)
-        if !Defaults.didRunApp {
-            let mainStoryboard = UIStoryboard(name: "Main", bundle: nil)
-            let exampleViewController = mainStoryboard.instantiateViewController(withIdentifier: "WelcomeViewController") as? WelcomeViewController
-            self.window?.rootViewController = exampleViewController
-            self.window?.makeKeyAndVisible()
-        }
 
         application.setMinimumBackgroundFetchInterval(UIApplication.backgroundFetchIntervalMinimum)
         if let profileId = Defaults.profileId {

--- a/Covid/Base.lproj/Main.storyboard
+++ b/Covid/Base.lproj/Main.storyboard
@@ -67,7 +67,6 @@
                                 </state>
                                 <connections>
                                     <action selector="agreeDidTap:" destination="Zak-E9-be5" eventType="touchUpInside" id="Dsz-R3-kcx"/>
-                                    <segue destination="RZt-J8-9gU" kind="presentation" id="uA0-Yv-kpI"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ieU-Bo-giF">
@@ -1139,22 +1138,6 @@ Bratislava, marec 2020
                 <placeholder placeholderIdentifier="IBFirstResponder" id="9Mv-iq-J64" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2198" y="-1068"/>
-        </scene>
-        <!--Navigation Controller-->
-        <scene sceneID="EaK-Kf-jat">
-            <objects>
-                <navigationController id="RZt-J8-9gU" sceneMemberID="viewController">
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="aaW-fY-6o2">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <connections>
-                        <segue destination="g0Z-rl-3mo" kind="relationship" relationship="rootViewController" id="7KV-ak-2k6"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="6jw-vr-P4L" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="3265" y="-1068"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="wx9-dr-UMF">
@@ -3147,8 +3130,7 @@ Zabránite tak šíreniu vírusu COVID-19.</string>
     </scenes>
     <inferredMetricsTieBreakers>
         <segue reference="tft-S4-wx5"/>
-        <segue reference="03C-rP-IWv"/>
-        <segue reference="Rme-BJ-GTw"/>
+        <segue reference="LCD-tO-Hlk"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="ID" width="26" height="27"/>

--- a/Covid/Extensions/UIStoryBoard.swift
+++ b/Covid/Extensions/UIStoryBoard.swift
@@ -31,9 +31,17 @@
 import Foundation
 import UIKit
 
+protocol HasStoryBoardIdentifier {
+    static var storyboardIdentifier: String { get }
+}
+
 extension UIStoryboard {
 
     static var main: UIStoryboard {
         UIStoryboard(name: "Main", bundle: nil)
+    }
+
+    class func controller<T: UIViewController>(ofType type: T.Type) -> T? where T: HasStoryBoardIdentifier {
+        main.instantiateViewController(withIdentifier: type.storyboardIdentifier) as? T
     }
 }

--- a/Covid/MainScreen/ForeignDecisionViewController.swift
+++ b/Covid/MainScreen/ForeignDecisionViewController.swift
@@ -36,7 +36,7 @@ final class ForeignDecisionViewController: UIViewController {
         // TODO: delegate
         presentingViewController?.dismiss(animated: true) {
             if let controller = (UIApplication.shared.delegate as? AppDelegate)?.visibleViewController() {
-                controller.performSegue(withIdentifier: "initQuarantine", sender: nil)
+                controller.performSegue(.startQuarantineFlow)
             }
         }
     }

--- a/Covid/Quarantine/AddressConfirmationViewController.swift
+++ b/Covid/Quarantine/AddressConfirmationViewController.swift
@@ -50,29 +50,7 @@ final class AddressConfirmationViewController: UIViewController {
         Defaults.quarantineLatitude = location?.latitude
         Defaults.quarantineLongitude = location?.longitude
 
-        if Defaults.phoneNumber != nil, let token = Defaults.mfaToken {
-            networkService.requestQuarantine(quarantineRequestData: QuarantineRequestData(mfaToken: token)) { [weak self] (result) in
-                DispatchQueue.main.async {
-                    switch result {
-                    case .success:
-                        LocationTracker.shared.startLocationTracking()
-
-                        // show face id
-                        self?.registerFaceId()
-
-                    case .failure:
-                        let alertController = UIAlertController(title: "Chyba", message: "Problém pri overovaní čisla.", preferredStyle: .alert)
-                        let cancelAction = UIAlertAction(title: "Overiť znova", style: .cancel) { (_) in
-                            self?.performSegue(withIdentifier: "quarantineVerifyNumber", sender: self)
-                        }
-                        alertController.addAction(cancelAction)
-                        self?.present(alertController, animated: true, completion: nil)
-                    }
-                }
-            }
-        } else {
-            performSegue(withIdentifier: "quarantineVerifyNumber", sender: self)
-        }
+        performSegue(.quarantineVerifyNumber)
     }
 
     @IBAction private func didTapChangeButton(_ sender: Any) {

--- a/Covid/Quarantine/CountryCodeViewController.swift
+++ b/Covid/Quarantine/CountryCodeViewController.swift
@@ -71,9 +71,7 @@ extension CountryCodeViewController {
     @objc
     func didTapSkip(_ sender: UIBarButtonItem) {
         presentingViewController?.dismiss(animated: true, completion: nil)
-        let mainStoryboard: UIStoryboard = UIStoryboard(name: "Main", bundle: nil)
-        let viewController = mainStoryboard.instantiateViewController(withIdentifier: "MainViewController") as UIViewController
-        UIApplication.shared.keyWindow?.rootViewController = viewController
+        UIApplication.shared.keyWindow?.rootViewController = UIStoryboard.controller(ofType: MainViewController.self)
     }
 
     @objc
@@ -98,7 +96,7 @@ extension CountryCodeViewController {
         let editAction = UIAlertAction(title: "Nie", style: .cancel, handler: nil)
         let yesAction = UIAlertAction(title: "Áno", style: .default) { [weak self] (_) in
             Defaults.tempPhoneNumber = number.replacingOccurrences(of: " ", with: "")
-            self?.performSegue(withIdentifier: "verification", sender: nil)
+            self?.performSegue(.phoneNumberVerification)
         }
         alert.addAction(editAction)
         alert.addAction(yesAction)

--- a/Covid/Quarantine/FaceID/FaceCaptureCompletedViewController.swift
+++ b/Covid/Quarantine/FaceID/FaceCaptureCompletedViewController.swift
@@ -31,6 +31,10 @@
 import Foundation
 import UIKit
 
+extension FaceCaptureCompletedViewController: HasStoryBoardIdentifier {
+    static let storyboardIdentifier = "faceCaptureComplete"
+}
+
 final class FaceCaptureCompletedViewController: UIViewController {
 
     var useCase: FaceIDUseCase = .registerFace
@@ -44,7 +48,7 @@ final class FaceCaptureCompletedViewController: UIViewController {
     @IBOutlet private weak var iconView: UIImageView!
 
     static func show(using presentationBlock: @escaping (FaceCaptureCompletedViewController) -> Void, onCompletion: @escaping () -> Void) {
-        if let viewController = UIStoryboard.main.instantiateViewController(withIdentifier: "faceCaptureComplete") as? FaceCaptureCompletedViewController {
+        if let viewController = UIStoryboard.controller(ofType: Self.self) {
             viewController.onCompletion = onCompletion
             presentationBlock(viewController)
         }

--- a/Covid/Quarantine/FaceID/FaceCaptureCoordinator.swift
+++ b/Covid/Quarantine/FaceID/FaceCaptureCoordinator.swift
@@ -70,17 +70,16 @@ extension FaceCaptureCoordinator {
     // MARK: Onboarding
 
     func showOnboarding(in navigationController: UINavigationController) {
-        let storyboard = UIStoryboard.main
-        if let viewController = storyboard.instantiateViewController(withIdentifier: "faceCaptureOnboarding") as? FaceCaptureOnboardingViewController {
-            viewController.onStart = { [weak self] in
-                if let controller = self?.startFaceCapture() {
-                    navigationController.pushViewController(controller, animated: true)
-                }
+        guard let viewController = UIStoryboard.controller(ofType: FaceCaptureOnboardingViewController.self) else { return }
+
+        viewController.onStart = { [weak self] in
+            if let controller = self?.startFaceCapture() {
+                navigationController.pushViewController(controller, animated: true)
             }
-            self.navigationController = navigationController
-            navigationController.pushViewController(viewController, animated: true)
-            step = .onboarding
         }
+        self.navigationController = navigationController
+        navigationController.pushViewController(viewController, animated: true)
+        step = .onboarding
     }
 
     // MARK: Face Capture

--- a/Covid/Quarantine/FaceID/FaceCaptureOnboardingViewController.swift
+++ b/Covid/Quarantine/FaceID/FaceCaptureOnboardingViewController.swift
@@ -31,6 +31,10 @@
 import Foundation
 import UIKit
 
+extension FaceCaptureOnboardingViewController: HasStoryBoardIdentifier {
+    static let storyboardIdentifier = "faceCaptureOnboarding"
+}
+
 final class FaceCaptureOnboardingViewController: UIViewController {
 
     var onStart: (() -> Void)?

--- a/Covid/Quarantine/MapViewController.swift
+++ b/Covid/Quarantine/MapViewController.swift
@@ -49,7 +49,7 @@ final class MapViewController: UIViewController {
         locationManager.requestLocation()
 
         if CLLocationManager.authorizationStatus() == .authorizedAlways || CLLocationManager.authorizationStatus() == .authorizedWhenInUse {
-            performSegue(withIdentifier: "search", sender: self)
+            performSegue(.searchAddress)
         }
 
         mapView.delegate = self
@@ -192,7 +192,7 @@ extension MapViewController: CLLocationManagerDelegate {
 
     func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
         if status != .notDetermined {
-            performSegue(withIdentifier: "search", sender: self)
+            performSegue(.searchAddress)
         }
     }
 }

--- a/Covid/Quarantine/VerificationCodeViewController.swift
+++ b/Covid/Quarantine/VerificationCodeViewController.swift
@@ -1,25 +1,25 @@
 /*-
-* Copyright (c) 2020 Sygic
-*
+ * Copyright (c) 2020 Sygic
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
  * The above copyright notice and this permission notice shall be included in
-* copies or substantial portions of the Software.
-*
+ * copies or substantial portions of the Software.
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-* THE SOFTWARE.
-*
-*/
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
 
 import UIKit
 import SwiftyUserDefaults
@@ -90,61 +90,35 @@ extension VerificationCodeViewController {
             DispatchQueue.main.async {
                 switch result {
                 case .success:
-                        self?.navigationItem.rightBarButtonItem = nil
-                        self?.activationCodeTextField.becomeFirstResponder()
+                    self?.navigationItem.rightBarButtonItem = nil
+                    self?.activationCodeTextField.becomeFirstResponder()
                 case .failure:
-                        let message = "Chyba pri vyžiadaní overovacieho kódu. Skúsiť znovu?"
-                        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-                        let editAction = UIAlertAction(title: "Nie", style: .cancel, handler: nil)
-                        let yesAction = UIAlertAction(title: "Áno", style: .default) { [weak self] (_) in
-                            self?.requestToken()
-                        }
-                        alert.addAction(editAction)
-                        alert.addAction(yesAction)
+                    let message = "Chyba pri vyžiadaní overovacieho kódu. Skúsiť znovu?"
+                    let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+                    let editAction = UIAlertAction(title: "Nie", style: .cancel, handler: nil)
+                    let yesAction = UIAlertAction(title: "Áno", style: .default) { [weak self] (_) in
+                        self?.requestToken()
+                    }
+                    alert.addAction(editAction)
+                    alert.addAction(yesAction)
 
-                        self?.present(alert, animated: true, completion: nil)
+                    self?.present(alert, animated: true, completion: nil)
                 }
             }
         }
-    }
-
-    private func showMain() {
-        presentingViewController?.dismiss(animated: true, completion: nil)
-        let mainStoryboard: UIStoryboard = UIStoryboard(name: "Main", bundle: nil)
-        let viewController = mainStoryboard.instantiateViewController(withIdentifier: "MainViewController") as UIViewController
-        UIApplication.shared.keyWindow?.rootViewController = viewController
     }
 
     private func didFillNumbers() {
         let tempToken = activationCodeTextField.text?.replacingOccurrences(of: " ", with: "")
         activationCodeTextField.resignFirstResponder()
 
-        if presentingViewController != nil {
-            networkService.requestMFATokenPhone(mfaTokenPhoneRequestData: MFATokenPhoneRequestData(mfaToken: tempToken)) { [weak self] (result) in
-                DispatchQueue.main.async {
-                    switch result {
-                    case .success:
-                            Defaults.phoneNumber = self?.phoneNumber
-                            Defaults.mfaToken = tempToken
-                            self?.showMain()
-
-                    case .failure:
-                        self?.requestFailed()
-                    }
-                }
-            }
-            return
-        }
-
-        networkService.requestQuarantine(quarantineRequestData: QuarantineRequestData(mfaToken: tempToken)) { [weak self] (result) in
+        networkService.requestMFATokenPhone(mfaTokenPhoneRequestData: MFATokenPhoneRequestData(mfaToken: tempToken)) { [weak self] (result) in
             DispatchQueue.main.async {
                 switch result {
                 case .success:
-                        Defaults.phoneNumber = self?.phoneNumber
-                        Defaults.mfaToken = tempToken
-                        LocationTracker.shared.startLocationTracking()
-                        self?.registerFaceId()
-
+                    Defaults.phoneNumber = self?.phoneNumber
+                    Defaults.mfaToken = tempToken
+                    self?.registerFaceId()
                 case .failure:
                     self?.requestFailed()
                 }
@@ -180,7 +154,7 @@ extension VerificationCodeViewController: UITextFieldDelegate {
 
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         if let text = textField.text,
-           let textRange = Range(range, in: text) {
+            let textRange = Range(range, in: text) {
             let updatedText = text.replacingCharacters(in: textRange,
                                                        with: string)
             let text = updatedText.replacingOccurrences(of: " ", with: "")

--- a/Covid/Segue.swift
+++ b/Covid/Segue.swift
@@ -1,0 +1,25 @@
+//
+//  Segue.swift
+//  Covid
+//
+//  Created by Boris Bielik on 07/04/2020.
+//  Copyright © 2020 Sygic. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+enum Segue: String {
+    case quarantineVerifyNumber
+    case startQuarantineFlow = "initQuarantine"
+    case foreignAlert
+    case searchAddress = "search"
+    case phoneNumberVerification = "verification"
+}
+
+extension UIViewController {
+
+    func performSegue(_ segue: Segue) {
+        performSegue(withIdentifier: segue.rawValue, sender: self)
+    }
+}

--- a/Covid/Services/LocationServices/BeaconManager.swift
+++ b/Covid/Services/LocationServices/BeaconManager.swift
@@ -76,7 +76,7 @@ final class BeaconManager: NSObject {
             ]
         )
     }
-    
+
     func activateLocationTrackingForBeacons() {
         locationManager.requestAlwaysAuthorization()
         locationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters

--- a/Covid/WelcomeViewController.swift
+++ b/Covid/WelcomeViewController.swift
@@ -31,9 +31,16 @@
 import UIKit
 import SwiftyUserDefaults
 
+extension WelcomeViewController: HasStoryBoardIdentifier {
+    static let storyboardIdentifier = "WelcomeViewController"
+}
+
 final class WelcomeViewController: UIViewController {
+
     @IBOutlet private var agreeButton: UIButton!
     @IBOutlet private var cooperationLabel: UILabel!
+
+    var onAgree: (() -> Void)?
 
     override func loadView() {
         super.loadView()
@@ -56,6 +63,6 @@ final class WelcomeViewController: UIViewController {
     }
 
     @IBAction private func agreeDidTap(_ sender: Any) {
-        Defaults.didRunApp = true
+        onAgree?()
     }
 }


### PR DESCRIPTION
# Changes
* user is no longer required to verify his phone number when app starts
* user is asked for phone number only in "quarantine" flow
* quarantine data are sent in the end of the quarantine flow


# New stuff in codebase

## Seamless instantiation of viewcontrollers defined in main storyboard

This dumb protocol 
```
protocol HasStoryBoardIdentifier {
    static var storyboardIdentifier: String { get }
}
```
in cooperation with new `UIStoryboard` extension:

```
extension UIStoryboard {

    class func controller<T: UIViewController>(ofType type: T.Type) -> T? where T: HasStoryBoardIdentifier {
        main.instantiateViewController(withIdentifier: type.storyboardIdentifier) as? T
    }
}
```

allows us to instantiate the VC's declared in storyboard in more seamless way:
Common way of instantiating the VC from storyboard looks like this:
```
let mainStoryboard: UIStoryboard = UIStoryboard(name: "Main", bundle: nil)
let viewController = mainStoryboard.instantiateViewController(withIdentifier: "MainViewController") as UIViewController
```

Here's new, type-safe way, that results into 1-liner:
```
UIStoryboard.controller(ofType: MainViewController.self)
```

## Segues
All segues are now listed in enum `Segue`:
```
enum Segue: String {
    case quarantineVerifyNumber
    case startQuarantineFlow = "initQuarantine"
    case foreignAlert
    case searchAddress = "search"
    case phoneNumberVerification = "verification"
}
```

Instead of using string-based APIs:
```
performSegue(withIdentifier: "initQuarantine", sender: nil)
```

we're now able to perform segues in a type-safe way:

```
performSegue(.startQuarantineFlow)
```

