### PR TITLE
Support for dynamic links

### DIFF
--- a/Covid/Covid.entitlements
+++ b/Covid/Covid.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:nczi.page.link</string>
+	</array>
 </dict>
 </plist>

--- a/Covid/Resources/Info.plist
+++ b/Covid/Resources/Info.plist
@@ -18,6 +18,19 @@
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>URL ID</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>sk.nczi.covid19</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>


### PR DESCRIPTION
* Adds `Associated Domains` support to covid app. 
Side-effect: App new supports `Associated Domains` from dev account. To reflect this change, I had to re-generate the provisioning profile for Appstore & reupload it to Bitrise. Additionally I created dev provisioning profile for testing purposes
* Adds custom url scheme

